### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ source $HOME/.bash_profile
 ```bash
 cd $HOME
 evmosd init $MONIKER --chain-id $CHAIN_ID
+evmosd config chain-id $CHAIN_ID
 evmosd config node tcp://localhost:$RPC_PORT
 evmosd config keyring-backend os # You can set it to "test" so you will not be asked for a password
 ```


### PR DESCRIPTION
adding ``` evmosd config chain-id $CHAIN_ID ``` again. It seems that people having problem when they are not running that command because the chain that set on the ```evmosd init $MONIKER --chain-id $CHAIN_ID``` it not working.